### PR TITLE
New base route for the application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 build.yml
-docker-compose.yml
 Dockerfile
+docker-compose.yml
 nile.yml
 data/keys.RDS
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 build.yml
-Dockerfile
-docker-compose.yml
 nile.yml
 data/keys.RDS
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM rstudio/plumber
+
+RUN mkdir -p /app/data
+
+WORKDIR /app/
+
+RUN R -e "install.packages(c('jsonlite','plumber','rcpp','rvest','stringr','tidyverse','xml2','vroom'))"
+
+## Copy data
+COPY ./data/ /app/data/
+COPY ./docs/ /app/docs/
+
+## Copy R files
+COPY entrypoint.R /app/entrypoint.R
+COPY ./plumber.R /app/plumber.R
+
+EXPOSE 8000
+
+CMD ["Rscript", "entrypoint.R"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ If you see an error in our summary or supplemental files, please submit a pull r
 
 **Do you use R?** Try out the [arcos api wrapper](https://github.com/wpinvestigative/arcos).
 
+**Do you use [Docker](https://docs.docker.com/desktop/)?** Run the application yourself on your local machine with the command: `docker-compose up`. 
+
 |  **Data Files** | **What** |
 | --- | --- |
 |  data_dictionary.csv | Descriptions of every field in the ARCOS raw data |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.7"
+
+services:
+  # This service runs the arcos_api application 
+  arcos_api:
+    build: .
+    expose:
+      - "8000"
+    ports:
+      - "8000:8000"
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="SwaggerUI" />
+  <title>SwaggerUI</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui.css" />
+</head>
+
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui-bundle.js" crossorigin></script>
+  <script>
+    window.onload = () => {
+      window.ui = SwaggerUIBundle({
+        url: 'http://localhost:8000/openapi.json',
+        dom_id: '#swagger-ui',
+      });
+    };
+  </script>
+</body>
+
+</html>

--- a/entrypoint.R
+++ b/entrypoint.R
@@ -1,0 +1,17 @@
+# entrypoint.R
+library(jsonlite)
+library(plumber)
+library(stringr)
+library(tidyverse)
+library(vroom)
+
+# When setting the docs, `index` and `static` function arguments can be supplied
+# * via `pr_set_docs()`
+# * or through URL query string variables
+pr("plumber.R") %>%
+  pr_static("/arcos/__docs__/", "./docs") %>%
+  pr_run(
+    host='0.0.0.0',
+    port = 8000,
+    docs = TRUE
+  )

--- a/plumber.R
+++ b/plumber.R
@@ -30,7 +30,7 @@ drug_types <- read_csv(paste0("data/drug_names.csv")) %>% pull(DRUG_NAME)
 #' @param county If provided, filter the data to only this county (e.g. 'Mingo')
 #' @param state If provided, filter the data to only this state (e.g. 'WV')
 #' @tag raw
-#' @get /v1/county_data
+#' @get /arcos/v1/county_data
 function(state, county, key){
   
   if (missing(key)) {
@@ -83,7 +83,7 @@ function(state, county, key){
 #' @param drug Filter the data to only this drug (e.g. 'FENTANYL')
 #' @param buyer_bus_act If included, filters the data to only this buyer type (e.g. 'HOSP/CLINIC' or 'RETAIL PHARMACY')
 #' @tag raw
-#' @get /v1/county_data_drug
+#' @get /arcos/v1/county_data_drug
 function(state, county, drug, buyer_bus_act, key){
   
   if (missing(key)) {
@@ -156,7 +156,7 @@ function(state, county, drug, buyer_bus_act, key){
 #' @param key Key needed to make query successful
 #' @param fips If provided, filter the data to only this county (e.g. '01001' for Autauga, Alabama)
 #' @tag raw
-#' @get /v1/county_fips_data
+#' @get /arcos/v1/county_fips_data
 function(fips, key){
   
   if (missing(key)) {
@@ -203,7 +203,7 @@ function(fips, key){
 #' @param drug Filter the data to only this drug (e.g. 'FENTANYL')
 #' @param buyer_bus_act If included, filters the data to only this buyer type (e.g. 'HOSP/CLINIC' or 'RETAIL PHARMACY')
 #' @tag raw
-#' @get /v1/county_fips_data_drug
+#' @get /arcos/v1/county_fips_data_drug
 function(drug, fips, buyer_bus_act, key){
   
   if (missing(key)) {
@@ -287,7 +287,7 @@ function(drug, fips, buyer_bus_act, key){
 #' @param county If provided, filter the data to only this county (e.g. 'Mingo')
 #' @param state If provided, filter the data to only this state (e.g. 'WV')
 #' @tag supplemental
-#' @get /v1/county_population
+#' @get /arcos/v1/county_population
 function(state, county, key){
   
   
@@ -335,7 +335,7 @@ function(state, county, key){
 #' Returns list of 330+ BUYER_DEA_NOs that we've identified as mail order or hospitals and not retail or chain pharmacies
 #' @param key Key needed to make query successful
 #' @tag supplemental
-#' @get /v1/not_pharmacies
+#' @get /arcos/v1/not_pharmacies
 function(key){
   
   
@@ -363,7 +363,7 @@ function(key){
 #' @param key Key needed to make query successful
 #' @param state If provided, filter the data to only this state (e.g. 'WV')
 #' @tag supplemental
-#' @get /v1/state_population
+#' @get /arcos/v1/state_population
 function(state, key){
   
   
@@ -402,7 +402,7 @@ function(state, key){
 #' @param county If provided, filter the data to only this county (e.g. 'Mingo')
 #' @param state If provided, filter the data to only this state (e.g. 'WV')
 #' @tag supplemental
-#' @get /v1/pharmacy_latlon
+#' @get /arcos/v1/pharmacy_latlon
 function(state, county, key){
   
   if (missing(key)) {
@@ -447,7 +447,7 @@ function(state, county, key){
 #' @param county If provided, filter the data to only this county (e.g. 'Mingo')
 #' @param state If provided, filter the data to only this state (e.g. 'WV')
 #' @tag supplemental
-#' @get /v1/pharmacy_counties
+#' @get /arcos/v1/pharmacy_counties
 function(state, county, key){
   
   if (missing(key)) {
@@ -492,7 +492,7 @@ function(state, county, key){
 #' @param county If provided, filter the data to only this county (e.g. 'Mingo')
 #' @param state If provided, filter the data to only this state (e.g. 'WV')
 #' @tag supplemental
-#' @get /v1/pharmacy_tracts
+#' @get /arcos/v1/pharmacy_tracts
 function(state, county, key){
   
   if (missing(key)) {
@@ -538,7 +538,7 @@ function(state, county, key){
 #' @param state If geoid isn't provided, filter the data to only this state (e.g. 'WV')
 #' @param geoid If provided, filter the data to the cbsa GEOID (e.g. '26580') 
 #' @tag supplemental
-#' @get /v1/pharmacy_cbsa
+#' @get /arcos/v1/pharmacy_cbsa
 function(geoid, state, county, key){
   
   if (missing(key)) {
@@ -589,7 +589,7 @@ function(geoid, state, county, key){
 #' @param key Key needed to make query successful
 #' @param buyer_dea_no Required number (e.g. 'AB0454176')
 #' @tag raw
-#' @get /v1/pharmacy_data
+#' @get /arcos/v1/pharmacy_data
 function(buyer_dea_no, key){
   
   if (missing(key)) {
@@ -639,7 +639,7 @@ function(buyer_dea_no, key){
 #' @param county If provided, filter the data to only this county (e.g. 'Mingo')
 #' @param state If provided, filter the data to only this state (e.g. 'WV')
 #' @tag raw
-#' @get /v1/buyer_details
+#' @get /arcos/v1/buyer_details
 function(state, county, key){
   
   if (missing(key)) {
@@ -686,7 +686,7 @@ function(state, county, key){
 #' @param county If provided, filter the data to only this county (e.g. 'Mingo')
 #' @param state If provided, filter the data to only this state (e.g. 'WV')
 #' @tag raw
-#' @get /v1/reporter_details
+#' @get /arcos/v1/reporter_details
 function(state, county, key){
   
   
@@ -734,7 +734,7 @@ function(state, county, key){
 #' @param county If provided, filter the data to only this county (e.g. 'Mingo')
 #' @param state If provided, filter the data to only this state (e.g. 'WV')
 #' @tag summary
-#' @get /v1/combined_county_annual
+#' @get /arcos/v1/combined_county_annual
 function(state, county, key){
   
   if (missing(key)) {
@@ -793,7 +793,7 @@ function(state, county, key){
 #' @param county If provided, filter the data to only this county (e.g. 'Mingo')
 #' @param state If provided, filter the data to only this state (e.g. 'WV')
 #' @tag summary
-#' @get /v1/combined_county_monthly
+#' @get /arcos/v1/combined_county_monthly
 function(state, county, key){
   
   if (missing(key)) {
@@ -851,7 +851,7 @@ function(state, county, key){
 #' @param county If provided, filter the data to only this county (e.g. 'Mingo')
 #' @param state If provided, filter the data to only this state (e.g. 'WV')
 #' @tag summary
-#' @get /v1/total_pharmacies_county
+#' @get /arcos/v1/total_pharmacies_county
 function(state, county, key){
   
   if (missing(key)) {
@@ -902,7 +902,7 @@ function(state, county, key){
 #' @param county If provided, filter the data to only this county (e.g. 'Mingo')
 #' @param state If provided, filter the data to only this state (e.g. 'WV')
 #' @tag summary
-#' @get /v1/total_manufacturers_county
+#' @get /arcos/v1/total_manufacturers_county
 function(state, county, key){
   
   if (missing(key)) {
@@ -953,7 +953,7 @@ function(state, county, key){
 #' @param county If provided, filter the data to only this county (e.g. 'Mingo')
 #' @param state If provided, filter the data to only this state (e.g. 'WV')
 #' @tag summary
-#' @get /v1/total_distributors_county
+#' @get /arcos/v1/total_distributors_county
 function(state, county, key){
   
   if (missing(key)) {
@@ -1003,7 +1003,7 @@ function(state, county, key){
 #' @param key Key needed to make query successful
 #' @param state If provided, filter the data to only this state (e.g. 'WV')
 #' @tag summary
-#' @get /v1/total_pharmacies_state
+#' @get /arcos/v1/total_pharmacies_state
 function(state, key){
   
   if (missing(key)) {
@@ -1044,7 +1044,7 @@ function(state, key){
 #' @param key Key needed to make query successful
 #' @param state If provided, filter the data to only this state (e.g. 'WV')
 #' @tag summary
-#' @get /v1/total_manufacturers_state
+#' @get /arcos/v1/total_manufacturers_state
 function(state, key){
   
   if (missing(key)) {
@@ -1086,7 +1086,7 @@ function(state, key){
 #' @param key Key needed to make query successful
 #' @param state If provided, filter the data to only this state (e.g. 'WV')
 #' @tag summary
-#' @get /v1/total_distributors_state
+#' @get /arcos/v1/total_distributors_state
 function(state, key){
   
   if (missing(key)) {
@@ -1129,7 +1129,7 @@ function(state, key){
 #' @param county If provided, filter the data to only this county (e.g. 'Mingo')
 #' @param state If provided, filter the data to only this state (e.g. 'WV')
 #' @tag summary
-#' @get /v1/combined_buyer_annual
+#' @get /arcos/v1/combined_buyer_annual
 function(state, county, key){
   
   if (missing(key)) {
@@ -1187,7 +1187,7 @@ function(state, county, key){
 #' @param county If provided, filter the data to only this county (e.g. 'Mingo')
 #' @param state If provided, filter the data to only this state (e.g. 'WV')
 #' @tag summary
-#' @get /v1/combined_buyer_monthly
+#' @get /arcos/v1/combined_buyer_monthly
 function(state, county, year, key){
   
   if (missing(key)) {
@@ -1250,7 +1250,7 @@ function(state, county, year, key){
 #' @param county If provided, filter the data to only this county (e.g. 'Mingo')
 #' @param state If provided, filter the data to only this state (e.g. 'WV')
 #' @tag supplemental
-#' @get /v1/county_list
+#' @get /arcos/v1/county_list
 function(state, county, key){
   
   if (missing(key)) {
@@ -1307,7 +1307,7 @@ function(state, county, key){
 #' Leave out county and state variables to pull entire country list
 #' @param key Key needed to make query successful
 #' @tag supplemental
-#' @get /v1/buyer_list
+#' @get /arcos/v1/buyer_list
 function(key){
   
   if (missing(key)) {
@@ -1336,7 +1336,7 @@ function(key){
 #' @param county If provided, filter the data to only this county (e.g. 'Mingo')
 #' @param state If provided, filter the data to only this state (e.g. 'WV')
 #' @tag summary
-#' @get /v1/combined_buyer_monthly
+#' @get /arcos/v1/combined_buyer_monthly
 function(state, county, year, key){
   
   if (missing(key)) {
@@ -1398,7 +1398,7 @@ function(state, county, year, key){
 #' Returns simple dataframe of drugs tracked in the ARCOS database
 #' @param key Key needed to make query successful
 #' @tag supplemental
-#' @get /v1/drug_list
+#' @get /arcos/v1/drug_list
 function(key){
   
   if (missing(key)) {
@@ -1426,7 +1426,7 @@ function(key){
 #' @param key Key needed to make query successful
 #' @serializer contentType list(type="text/tab-separated-values")
 #' @tag raw
-#' @get /v1/all_the_data
+#' @get /arcos/v1/all_the_data
 function(key, res){
   
   if (missing(key)) {
@@ -1450,19 +1450,12 @@ function(key, res){
   }
 }
 
-
-# #' @get /v1/docs/
-# function() {
-# return(pr$swaggerFile());
-# }
-
 #' Health check for ALB (Part of deployment process, not part of the API)
 #' @tag z_ignore
 #' @get /healthcheck
 function() {
   return(list(message="Everything is fine."));
 }
-
 
 #* @filter cors
 cors <- function(res) {
@@ -1471,8 +1464,3 @@ cors <- function(res) {
   res$setHeader("Access-Control-Allow-Headers", "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range")
   plumber::forward()
 }
-
-
-#pr <- plumb("plumber.R")  # Where 'plumber.R' is the location of the file shown above
-# r$run(host="0.0.0.0",port=8000)
-

--- a/plumber.R
+++ b/plumber.R
@@ -1103,7 +1103,7 @@ function(state, key){
         
       } else {
         county_fips <- county_relationship_file_only %>% pull(countyfips)
-        
+
         state_abb <- str_to_lower(state_abb)
         
         url <- paste0(base_url, state_abb, "-county-distributor.tsv")
@@ -1452,7 +1452,7 @@ function(key, res){
 
 #' Health check for ALB (Part of deployment process, not part of the API)
 #' @tag z_ignore
-#' @get /healthcheck
+#' @get /arcos/healthcheck
 function() {
   return(list(message="Everything is fine."));
 }


### PR DESCRIPTION
This PR alters the arcos api application. These alterations were made in order to have the application fit to the standards of an Akamai distribution. 

There are two primary changes. 

First: Most sub-routes of the application are now served through a `/arcos/` url prefix. 

Second: To that end, we've added a new route for the useful swagger UI that can be used to construct api calls. In addition to `/__docs__/`, this feature is now also available at `/arcos/__docs__/`. 