### PR TITLE
chore: updating index.html for documentation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-
+​
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -8,7 +8,7 @@
   <title>SwaggerUI</title>
   <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui.css" />
 </head>
-
+​
 <body>
   <div id="swagger-ui"></div>
   <script src="https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui-bundle.js" crossorigin></script>
@@ -17,9 +17,28 @@
       window.ui = SwaggerUIBundle({
         url: 'http://localhost:8000/openapi.json',
         dom_id: '#swagger-ui',
+        plugins: [
+          SwaggerUIBundle.plugins.DownloadUrl,
+          // Custom plugin that replaces the server list with the current url
+          function () {
+            return {
+              statePlugins: {
+                spec: {
+                  wrapActions: {
+                    updateJsonSpec: function (oriAction, system) {
+                      return (spec) => {
+                        spec.servers = [{ url: `${window.location.origin}` }]
+                        return oriAction(spec)
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
       });
     };
   </script>
 </body>
-
 </html>


### PR DESCRIPTION
There was a minor bug in the new swagger documentation where the base "server" value was being returned as "localhost:8000/arcos/"

This was causing issues requesting from the new `/arcos/` prefixed api routes. 

This PR adds a plugin to set the "server" value appropriately. 

This is a band-aid and would be better fixed by a fully integrated solution for setting swagger documentation on a base path prefix. Pending some development on the following github issues: 

* [rstudio/plumber#836](https://github.com/rstudio/plumber/issues/836)
* [rstudio/plumber#475](https://github.com/rstudio/plumber/issues/475)
* [rstudio/plumber#394](https://github.com/rstudio/plumber/issues/394)